### PR TITLE
fix: Use lowercasing for pulls

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -31,6 +31,7 @@ while IFS= read -r line; do
     html=$(curl -sSLNZ "https://github.com/$owner/$repo/pkgs/container/$image")
     raw_pulls=$(echo -e "$html" | grep -Pzo '(?<=Total downloads</span>\n          <h3 title=")\d*')
     pulls=$(echo -e "$html" | grep -Pzo "(?<=Total downloads</span>\n          <h3 title=\"$raw_pulls\">)[^<]*")
+    pulls="${pulls,,}"
     date=$(date -u +"%Y-%m-%d")
 
     # ...if we get a response


### PR DESCRIPTION
The official Docker pulls badge display the pulls count with lower casing, for example:

3.1k pulls

This badge displays it in uppercasing:

3.1K pulls

When displaying them side-by-side this looks a bit weird, so maybe better to use lowercase here too.

It also display 1 digit less:

4.3k pulls

While this badge displays 2:

4.32K pulls
